### PR TITLE
Fix week vs weak

### DIFF
--- a/es.json
+++ b/es.json
@@ -36,7 +36,7 @@
       "weekHeader":"Sem",
       "firstDayOfWeek":1,
       "dateFormat":"dd/mm/yyyy",
-      "weak":"Semana",
+      "weak":"Débil",
       "medium":"Medio",
       "strong":"Fuerte",
       "passwordPrompt":"Escriba una contraseña",


### PR DESCRIPTION
The translation mistook "weak" for "week" and translated it to the word "week" in spanish. This is now fixed.