### PR TITLE
removed trailing commas in package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
         "primevue",
         "primefaces",
         "i18n",
-        "l7n",
+        "l7n"
     ],
     "files": [
         "**/*.json"
-    ],
+    ]
 }


### PR DESCRIPTION
npm couldn't handle the package json due to training commas. the json should now be valid, based on an online json syntax checker

partially resolves #71 