### PR TITLE
Fix date format

### DIFF
--- a/bg.json
+++ b/bg.json
@@ -15,7 +15,7 @@
         "weekHeader": "Сд",
         "firstDayOfWeek": 1,
         "showMonthAfterYear": false,
-        "dateFormat": "dd/mm/yyyy",
+        "dateFormat": "dd/mm/yy",
         "weak": "Слаба",
         "medium": "Средна",
         "strong": "Добра",

--- a/fa.json
+++ b/fa.json
@@ -41,7 +41,7 @@
         "weekHeader": "هفته",
         "firstDayOfWeek": 6,
         "showMonthAfterYear": true,
-        "dateFormat": "yyyy/mm/dd",
+        "dateFormat": "yy/mm/dd",
         "weak": "هفته",
         "medium": "متوسط",
         "strong": "قوی",

--- a/gr.json
+++ b/gr.json
@@ -70,7 +70,7 @@
     "weekHeader": "Wk",
     "firstDayOfWeek": 0,
     "showMonthAfterYear": false,
-    "dateFormat": "dd/mm/yyyy",
+    "dateFormat": "dd/mm/yy",
     "weak": "Αδύναμος",
     "medium": "Μεσαίος",
     "strong": "Δυνατός",

--- a/kg.json
+++ b/kg.json
@@ -56,7 +56,7 @@
        "weekHeader": "Апта",
        "firstDayOfWeek": 1,
         "showMonthAfterYear": false,
-       "dateFormat": "dd.mm.yyyy",
+       "dateFormat": "dd.mm.yy",
        "weak": "Алсыз",
        "medium": "Орто",
        "strong": "Күчтүү",
@@ -119,4 +119,3 @@
        }
     }
  }
- 

--- a/ru.json
+++ b/ru.json
@@ -56,7 +56,7 @@
       "weekHeader": "Нед.",
       "firstDayOfWeek": 1,
       "showMonthAfterYear": false,
-      "dateFormat": "dd.mm.yyyy",
+      "dateFormat": "dd.mm.yy",
       "weak": "Простой",
       "medium": "Нормальный",
       "strong": "Хороший",

--- a/sl.json
+++ b/sl.json
@@ -56,7 +56,7 @@
       "weekHeader": "Wk",
       "firstDayOfWeek": 0,
       "showMonthAfterYear": false,
-      "dateFormat": "dd.mm.yyyy",
+      "dateFormat": "dd.mm.yy",
       "weak": "Teden",
       "medium": "Medium",
       "strong": "Povdarjen",


### PR DESCRIPTION
Correction of date format in 6 translations (from `yyyy` to `yy`).

Year format cannot be `yyyy`, see [PrimeNG](https://primeng.org/calendar#format), [PrimeReact](https://primereact.org/calendar/#format), [PrimeVue](https://primevue.org/calendar/#format) documentation:
- _y_ - year (two digit)
- _yy_ - year (four digit)