### PR TITLE
feat: Add missing translation 'fileSizeTypes' in zh-tw

### DIFF
--- a/zh-TW.json
+++ b/zh-TW.json
@@ -30,6 +30,7 @@
     "cancel": "取消",
     "completed": "已完成",
     "pending": "待定",
+    "fileSizeTypes": ["B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"],
     "dayNames": [
       "星期日", 
       "星期一", 


### PR DESCRIPTION
the key **fileSizeTypes** exists in english locale but missing in traditional chinese locale file