### PR TITLE
chore: Add "Now" translation in Catalan and Spanish

### DIFF
--- a/ca.json
+++ b/ca.json
@@ -94,6 +94,7 @@
             "Des"
         ],
         "today": "Avui",
+        "now": "Ara",
         "weekHeader": "Setm",
         "firstDayOfWeek": 1,
         "showMonthAfterYear": false,

--- a/es.json
+++ b/es.json
@@ -94,6 +94,7 @@
             "Dic"
         ],
         "today": "Hoy",
+        "now": "Ahora",
         "weekHeader": "Sem",
         "firstDayOfWeek": 1,
         "showMonthAfterYear": false,


### PR DESCRIPTION
- Added `Now` translation in `ca` and `es` languages.