### PR TITLE
add missing key emptySearchMessage using emptyFilterMessage

### DIFF
--- a/es.json
+++ b/es.json
@@ -104,6 +104,7 @@
         "strong": "Fuerte",
         "passwordPrompt": "Escriba una contraseña",
         "emptyFilterMessage": "Sin opciones disponibles",
+        "emptySearchMessage": "Sin opciones disponibles",
         "emptyMessage": "No se han encontrado resultados",
         "aria": {
             "trueLabel": "Verdadero",


### PR DESCRIPTION
key _emptyFilterMessage_ is [depreacted](https://primevue.org/configuration/#localeapi) (prime vue, 3.7)

Used the value for _emptyFilterMessage_ but the key wasn't deleted.