### PR TITLE
fix: turkish dateFormat set

### DIFF
--- a/tr.json
+++ b/tr.json
@@ -57,7 +57,7 @@
        "weekHeader":"Hf",
        "firstDayOfWeek":0,
        "showMonthAfterYear": false,
-       "dateFormat":"dd/mm/yy",
+       "dateFormat":"dd.mm.yy",
        "weak":"Zayıf",
        "medium":"Orta",
        "strong":"Güçlü",


### PR DESCRIPTION
Turkish date format notation must use `.` 

Source: 
https://en.wikipedia.org/wiki/Date_and_time_notation_in_Turkey#:~:text=In%20Turkey%2C%20dates%20are%20written,format%2C%2010%20Kas%C4%B1m%202023%20).