### PR TITLE
Improve Polish translation for emptyMessage key

### DIFF
--- a/pl.json
+++ b/pl.json
@@ -46,7 +46,7 @@
       "Sob"
     ],
     "emptyFilterMessage": "Brak wyników wyszukiwania",
-    "emptyMessage": "Brak danych",
+    "emptyMessage": "Nie ma dostępnych opcji",
     "emptySearchMessage": "Nie znaleziono wyników",
     "emptySelectionMessage": "Brak wybranego elementu",
     "endsWith": "Kończy się na",


### PR DESCRIPTION
A coworker on our i18n team reports that the current Polish translation for the `emptyMessage` key is confusing and/or inaccurate.

The current message for the key `emptyMessage` in English reads: "No available options"

The current Polish string is "Brak danych", which translated literally means "no data".

The slight loss of meaning makes this confusing for our Polish colleagues, as this shows up in various components that don't have options loaded yet.

This PR corrects the translation to: `Nie ma dostępnych opcji`, which translates more directly to "no options available".

