### PR TITLE
Fix dateFormat for Czech locale

### DIFF
--- a/cs.json
+++ b/cs.json
@@ -15,7 +15,7 @@
     "custom": "Vlastní",
     "dateAfter": "Datum je po",
     "dateBefore": "Datum je před",
-    "dateFormat": "dd.mm.rrrr",
+    "dateFormat": "d. m. yy",
     "dateIs": "Datum je",
     "dateIsNot": "Datum není",
     "dayNames": [


### PR DESCRIPTION
Fixes incorrectly translated year placeholder and switches to more commonly used date format.