### PR TITLE
Fix: Renames 'previousPageLabel' translation key to 'prevPageLabel'

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ pnpm add primelocale
 
 - [PrimeReact Sandbox](https://stackblitz.com/edit/axcck4?file=src%2FApp.tsx)
 
-When copying the local file to use, it is advisable to remove the object key in the json. For example, instead of having 
+When copying the local file to use, it is advisable to remove the object key in the json. For example, instead of having
 
 ```js
 {
@@ -157,7 +157,7 @@ Use:
 | aria.passwordHide | Password Hide
 | aria.passwordShow | Password Show
 | aria.previous | Previous
-| aria.previousPageLabel | Previous Page
+| aria.prevPageLabel | Previous Page
 | aria.removeLabel | Remove
 | aria.rotateLeft | Rotate Left
 | aria.rotateRight | Rotate Right

--- a/ar-tn.json
+++ b/ar-tn.json
@@ -164,7 +164,7 @@
       "passwordHide": "اخفاء كلمة المرور",
       "passwordShow": "عرض كلمة المرور",
       "previous": "السابق",
-      "previousPageLabel": "الصفحة السابقة",
+      "prevPageLabel": "الصفحة السابقة",
       "removeLabel": "يزيل",
       "rotateLeft": "تدوير بأتجاه اليسار",
       "rotateRight": "تدوير بإتجاه اليمين",

--- a/ar.json
+++ b/ar.json
@@ -164,7 +164,7 @@
       "passwordHide": "اخفاء كلمة المرور",
       "passwordShow": "عرض كلمة المرور",
       "previous": "السابق",
-      "previousPageLabel": "الصفحة السابقة",
+      "prevPageLabel": "الصفحة السابقة",
       "removeLabel": "إزالة",
       "rotateLeft": "تدوير بأتجاه اليسار",
       "rotateRight": "تدوير بإتجاه اليمين",

--- a/bg.json
+++ b/bg.json
@@ -164,7 +164,7 @@
       "passwordHide": "Скриване на паролата",
       "passwordShow": "Покажи парола",
       "previous": "Предишен",
-      "previousPageLabel": "Предишна страница",
+      "prevPageLabel": "Предишна страница",
       "removeLabel": "Премахване",
       "rotateLeft": "Завърти наляво",
       "rotateRight": "Завъртане надясно",

--- a/bn.json
+++ b/bn.json
@@ -104,7 +104,7 @@
           "passwordHide": "পাসওয়ার্ড লুকান",
           "passwordShow": "পাসওয়ার্ড দেখান",
           "previous": "পূর্ববর্তী",
-          "previousPageLabel": "পূর্ববর্তী পৃষ্ঠা",
+          "prevPageLabel": "পূর্ববর্তী পৃষ্ঠা",
           "removeLabel": "সরান",
           "rotateLeft": "বামদিকে ঘোরান",
           "rotateRight": "ডানদিকে ঘোরান",
@@ -129,4 +129,3 @@
        }
     }
  }
- 

--- a/ca.json
+++ b/ca.json
@@ -164,7 +164,7 @@
       "passwordHide": "Amaga la contrasenya",
       "passwordShow": "Ensenya la contrasenya",
       "previous": "Anterior",
-      "previousPageLabel": "Pàgina anterior",
+      "prevPageLabel": "Pàgina anterior",
       "removeLabel": "Eliminar",
       "rotateLeft": "Girar a l'esquerra",
       "rotateRight": "Girar a la dreta",

--- a/ckb.json
+++ b/ckb.json
@@ -164,7 +164,7 @@
       "passwordHide": "شاردنەوەی پاسۆرد",
       "passwordShow": "وشەی نهێنیەکەم پیشان ده",
       "previous": "پێشتر",
-      "previousPageLabel": "لاپەڕەی پێشوو",
+      "prevPageLabel": "لاپەڕەی پێشوو",
       "removeLabel": "لابردن",
       "rotateLeft": "بەلای چەپدا بیسووڕێنە",
       "rotateRight": "بەلای ڕاستدا بیسووڕێنە",

--- a/cs.json
+++ b/cs.json
@@ -164,7 +164,7 @@
       "passwordHide": "Skrýt heslo",
       "passwordShow": "Zobrazit heslo",
       "previous": "Předchozí",
-      "previousPageLabel": "Předchozí strana",
+      "prevPageLabel": "Předchozí strana",
       "removeLabel": "Odstranit",
       "rotateLeft": "Otočit doleva",
       "rotateRight": "Otočit doprava",

--- a/da.json
+++ b/da.json
@@ -164,7 +164,7 @@
       "passwordHide": "Skjul adgangskode",
       "passwordShow": "Vis adgangskode",
       "previous": "Forrige",
-      "previousPageLabel": "Forrige side",
+      "prevPageLabel": "Forrige side",
       "removeLabel": "Fjerne",
       "rotateLeft": "Roter mod venstre",
       "rotateRight": "Roter mod højre",

--- a/de-at.json
+++ b/de-at.json
@@ -164,7 +164,7 @@
       "passwordHide": "Passwort verbergen",
       "passwordShow": "Passwort anzeigen",
       "previous": "Vorherige",
-      "previousPageLabel": "Vorherige Seite",
+      "prevPageLabel": "Vorherige Seite",
       "removeLabel": "Entfernen",
       "rotateLeft": "Nach links drehen",
       "rotateRight": "Nach rechts drehen",

--- a/de-ch.json
+++ b/de-ch.json
@@ -164,7 +164,7 @@
       "passwordHide": "Passwort verbergen",
       "passwordShow": "Passwort anzeigen",
       "previous": "Vorherige",
-      "previousPageLabel": "Vorherige Seite",
+      "prevPageLabel": "Vorherige Seite",
       "removeLabel": "Entfernen",
       "rotateLeft": "Nach links drehen",
       "rotateRight": "Nach rechts drehen",

--- a/de.json
+++ b/de.json
@@ -164,7 +164,7 @@
       "passwordHide": "Passwort verbergen",
       "passwordShow": "Passwort anzeigen",
       "previous": "Vorherige",
-      "previousPageLabel": "Vorherige Seite",
+      "prevPageLabel": "Vorherige Seite",
       "removeLabel": "Entfernen",
       "rotateLeft": "Nach links drehen",
       "rotateRight": "Nach rechts drehen",

--- a/el.json
+++ b/el.json
@@ -164,7 +164,7 @@
       "passwordHide": "Απόκρυψη κωδικού πρόσβασης",
       "passwordShow": "Δείξε τον κωδικό",
       "previous": "Προηγούμενο",
-      "previousPageLabel": "Προηγούμενη Σελίδα",
+      "prevPageLabel": "Προηγούμενη Σελίδα",
       "removeLabel": "Αφαιρώ",
       "rotateLeft": "Περιστροφή αριστερά",
       "rotateRight": "Περιστροφή δεξιά",

--- a/en-au.json
+++ b/en-au.json
@@ -164,7 +164,7 @@
       "passwordHide": "Hide Password",
       "passwordShow": "Show Password",
       "previous": "Previous",
-      "previousPageLabel": "Previous Page",
+      "prevPageLabel": "Previous Page",
       "removeLabel": "Remove",
       "rotateLeft": "Rotate Left",
       "rotateRight": "Rotate Right",

--- a/en-gb.json
+++ b/en-gb.json
@@ -164,7 +164,7 @@
       "passwordHide": "Hide Password",
       "passwordShow": "Show Password",
       "previous": "Previous",
-      "previousPageLabel": "Previous Page",
+      "prevPageLabel": "Previous Page",
       "removeLabel": "Remove",
       "rotateLeft": "Rotate Left",
       "rotateRight": "Rotate Right",

--- a/en.json
+++ b/en.json
@@ -104,7 +104,7 @@
          "passwordHide": "Hide Password",
          "passwordShow": "Show Password",
          "previous": "Previous",
-         "previousPageLabel": "Previous Page",
+         "prevPageLabel": "Previous Page",
          "removeLabel": "Remove",
          "rotateLeft": "Rotate Left",
          "rotateRight": "Rotate Right",

--- a/es.json
+++ b/es.json
@@ -164,7 +164,7 @@
       "passwordHide": "Contraseña oculta",
       "passwordShow": "Mostrar contraseña",
       "previous": "Anterior",
-      "previousPageLabel": "Página Anterior",
+      "prevPageLabel": "Página Anterior",
       "removeLabel": "Eliminar",
       "rotateLeft": "Girar a la izquierda",
       "rotateRight": "Girar a la derecha",

--- a/fa.json
+++ b/fa.json
@@ -164,7 +164,7 @@
       "passwordHide": "پنهان کردن رمز عبور",
       "passwordShow": "نمایش رمز عبور",
       "previous": "قبلی",
-      "previousPageLabel": "صفحه قبل",
+      "prevPageLabel": "صفحه قبل",
       "removeLabel": "برداشتن",
       "rotateLeft": "چرخش به سمت چپ",
       "rotateRight": "چرخش به سمت راست",

--- a/fi.json
+++ b/fi.json
@@ -164,7 +164,7 @@
       "passwordHide": "Piilota salasana",
       "passwordShow": "Näytä salasana",
       "previous": "Edellinen",
-      "previousPageLabel": "Edellinen sivu",
+      "prevPageLabel": "Edellinen sivu",
       "prevPageLabel": "Edellinen sivu",
       "removeLabel": "Poista",
       "rotateLeft": "Pyöritä vasemmalle",

--- a/fr.json
+++ b/fr.json
@@ -164,7 +164,7 @@
       "passwordHide": "Masquer le mot de passe",
       "passwordShow": "Montrer le mot de passe",
       "previous": "Précédent",
-      "previousPageLabel": "Page précédente",
+      "prevPageLabel": "Page précédente",
       "removeLabel": "Retirer",
       "rotateLeft": "Tourner vers la gauche",
       "rotateRight": "Tourner vers la droite",

--- a/he.json
+++ b/he.json
@@ -164,7 +164,7 @@
       "passwordHide": "הסתר סיסמא",
       "passwordShow": "הראה סיסמה",
       "previous": "קודם",
-      "previousPageLabel": "עמוד קודם",
+      "prevPageLabel": "עמוד קודם",
       "removeLabel": "לְהַסִיר",
       "rotateLeft": "סובב שמאלה",
       "rotateRight": "סובב ימינה",

--- a/hi.json
+++ b/hi.json
@@ -164,7 +164,7 @@
       "passwordHide": "पासवर्ड छिपाएं",
       "passwordShow": "पासवर्ड दिखाए",
       "previous": "पिछला",
-      "previousPageLabel": "पिछला पृष्ठ",
+      "prevPageLabel": "पिछला पृष्ठ",
       "removeLabel": "निकालना",
       "rotateLeft": "बाईं ओर घुमाएं",
       "rotateRight": "दाईं ओर घुमाएं",

--- a/hr.json
+++ b/hr.json
@@ -164,7 +164,7 @@
       "passwordHide": "Sakrij lozinku",
       "passwordShow": "Pokaži lozinku",
       "previous": "Prethodno",
-      "previousPageLabel": "Prethodna stranica",
+      "prevPageLabel": "Prethodna stranica",
       "removeLabel": "Ukloniti",
       "rotateLeft": "Rotiraj ulijevo",
       "rotateRight": "Rotiraj udesno",

--- a/hu.json
+++ b/hu.json
@@ -164,7 +164,7 @@
       "passwordHide": "Jelszó elrejtése",
       "passwordShow": "Mutasd a jelszót",
       "previous": "Előző",
-      "previousPageLabel": "Előző oldal",
+      "prevPageLabel": "Előző oldal",
       "removeLabel": "Távolítsa el",
       "rotateLeft": "Forgatás balra",
       "rotateRight": "Forgatás jobbra",

--- a/id.json
+++ b/id.json
@@ -164,7 +164,7 @@
       "passwordHide": "Sembunyikan Kata Sandi",
       "passwordShow": "Tampilkan Kata Sandi",
       "previous": "Sebelumnya",
-      "previousPageLabel": "Halaman Sebelumnya",
+      "prevPageLabel": "Halaman Sebelumnya",
       "removeLabel": "Menghapus",
       "rotateLeft": "Putar ke Kiri",
       "rotateRight": "Putar ke Kanan",

--- a/it.json
+++ b/it.json
@@ -164,7 +164,7 @@
       "passwordHide": "Nascondi password",
       "passwordShow": "Mostra password",
       "previous": "Precedente",
-      "previousPageLabel": "Pagina precedente",
+      "prevPageLabel": "Pagina precedente",
       "removeLabel": "Rimuovere",
       "rotateLeft": "Ruota a sinistra",
       "rotateRight": "Ruota a destra",

--- a/ja.json
+++ b/ja.json
@@ -164,7 +164,7 @@
       "passwordHide": "パスワードを隠す",
       "passwordShow": "パスワードを表示",
       "previous": "前",
-      "previousPageLabel": "前のページ",
+      "prevPageLabel": "前のページ",
       "removeLabel": "取り除く",
       "rotateLeft": "左に回転",
       "rotateRight": "右に回転",

--- a/kk.json
+++ b/kk.json
@@ -164,7 +164,7 @@
       "passwordHide": "Құпия сөзді жасыру",
       "passwordShow": "Құпия сөзді көрсету",
       "previous": "Алдыңғы",
-      "previousPageLabel": "Алдыңғы бет",
+      "prevPageLabel": "Алдыңғы бет",
       "removeLabel": "Жою",
       "rotateLeft": "Солға бұру",
       "rotateRight": "Оңға бұру",

--- a/km.json
+++ b/km.json
@@ -165,7 +165,7 @@
       "passwordHide": "លាក់ពាក្យសម្ងាត់",
       "passwordShow": "បង្ហាញពាក្យសម្ងាត់",
       "previous": "មុន",
-      "previousPageLabel": "ទំព័រមុន",
+      "prevPageLabel": "ទំព័រមុន",
       "removeLabel": "ដកចេញ",
       "rotateLeft": "បង្វិល​ឆ្វេង",
       "rotateRight": "បង្វិលស្តាំ",

--- a/ko.json
+++ b/ko.json
@@ -164,7 +164,7 @@
       "passwordHide": "비밀번호 숨기기",
       "passwordShow": "비밀번호 표시",
       "previous": "이전",
-      "previousPageLabel": "이전 페이지",
+      "prevPageLabel": "이전 페이지",
       "removeLabel": "제거하다",
       "rotateLeft": "왼쪽으로 회전",
       "rotateRight": "오른쪽으로 회전",

--- a/ku.json
+++ b/ku.json
@@ -164,7 +164,7 @@
       "passwordHide": "Şîfre veşêre",
       "passwordShow": "Şîfre nîşan bide",
       "previous": "پێشوو",
-      "previousPageLabel": "پەڕەی پێشوو",
+      "prevPageLabel": "پەڕەی پێشوو",
       "removeLabel": "Dûrxistin",
       "rotateLeft": "بەرانچوونی لە چەپ",
       "rotateRight": "بەرانچوونی لە ڕاست",

--- a/ky.json
+++ b/ky.json
@@ -164,7 +164,7 @@
       "passwordHide": "Сырсөздү жашыруу",
       "passwordShow": "Сыр сөздү көрсөтүү",
       "previous": "Мурунку",
-      "previousPageLabel": "Мурунку барак",
+      "prevPageLabel": "Мурунку барак",
       "removeLabel": "Алып салуу",
       "rotateLeft": "Солго буруу",
       "rotateRight": "Оңго буруу",

--- a/lv.json
+++ b/lv.json
@@ -164,7 +164,7 @@
       "passwordHide": "Slēpt paroli",
       "passwordShow": "Rādīt paroli",
       "previous": "Iepriekšējais",
-      "previousPageLabel": "Iepriekšējā lapa",
+      "prevPageLabel": "Iepriekšējā lapa",
       "removeLabel": "Noņemt",
       "rotateLeft": "Pagriezt pa kreisi",
       "rotateRight": "Pagriezt pa labi",

--- a/ms.json
+++ b/ms.json
@@ -164,7 +164,7 @@
       "passwordHide": "Sembunyikan Kata Laluan",
       "passwordShow": "Tunjukkan Kata Laluan",
       "previous": "Sebelumnya",
-      "previousPageLabel": "Muka Surat Sebelumnya",
+      "prevPageLabel": "Muka Surat Sebelumnya",
       "removeLabel": "Alih keluar",
       "rotateLeft": "Putar Ke Kiri",
       "rotateRight": "Putar Ke Kanan",

--- a/nb-no.json
+++ b/nb-no.json
@@ -164,7 +164,7 @@
       "passwordHide": "Skjul passord",
       "passwordShow": "Vis passord",
       "previous": "Forrige",
-      "previousPageLabel": "Forrige side",
+      "prevPageLabel": "Forrige side",
       "removeLabel": "Fjerne",
       "rotateLeft": "Roter til venstre",
       "rotateRight": "Roter til høyre",

--- a/nl.json
+++ b/nl.json
@@ -164,7 +164,7 @@
       "passwordHide": "Verberg wachtwoord",
       "passwordShow": "Laat wachtwoord zien",
       "previous": "Vorige",
-      "previousPageLabel": "Vorige pagina",
+      "prevPageLabel": "Vorige pagina",
       "removeLabel": "Verwijderen",
       "rotateLeft": "Draai linksom",
       "rotateRight": "Draai rechtsom",

--- a/pl.json
+++ b/pl.json
@@ -176,7 +176,7 @@
       "passwordHide": "Ukryj hasło",
       "passwordShow": "Pokaż hasło",
       "previous": "Poprzedni",
-      "previousPageLabel": "Poprzednia strona",
+      "prevPageLabel": "Poprzednia strona",
       "removeLabel": "Usunąć",
       "rotateLeft": "Obróć w lewo",
       "rotateRight": "Obróć w prawo",

--- a/pt-br.json
+++ b/pt-br.json
@@ -164,7 +164,7 @@
       "passwordHide": "Esconder a senha",
       "passwordShow": "Mostrar senha",
       "previous": "Anterior",
-      "previousPageLabel": "Página Anterior",
+      "prevPageLabel": "Página Anterior",
       "removeLabel": "Remover",
       "rotateLeft": "Rotacionar para a Esquerda",
       "rotateRight": "Rotacionar para a Direita",

--- a/pt.json
+++ b/pt.json
@@ -165,7 +165,7 @@
       "passwordHide": "Esconder a senha",
       "passwordShow": "Mostrar senha",
       "previous": "Anterior",
-      "previousPageLabel": "Página Anterior",
+      "prevPageLabel": "Página Anterior",
       "removeLabel": "Remover",
       "rotateLeft": "Girar à Esquerda",
       "rotateRight": "Girar à Direita",

--- a/ro.json
+++ b/ro.json
@@ -164,7 +164,7 @@
       "passwordHide": "Ascundeți parola",
       "passwordShow": "Arata parola",
       "previous": "Precedent",
-      "previousPageLabel": "Pagina precedentă",
+      "prevPageLabel": "Pagina precedentă",
       "removeLabel": "Elimina",
       "rotateLeft": "Rotiți la stânga",
       "rotateRight": "Rotiți la dreapta",

--- a/ru.json
+++ b/ru.json
@@ -164,7 +164,7 @@
       "passwordHide": "Скрыть пароль",
       "passwordShow": "Показать пароль",
       "previous": "Предыдущий",
-      "previousPageLabel": "Предыдущая страница",
+      "prevPageLabel": "Предыдущая страница",
       "removeLabel": "Удалить",
       "rotateLeft": "Повернуть влево",
       "rotateRight": "Повернуть вправо",

--- a/sk.json
+++ b/sk.json
@@ -164,7 +164,7 @@
       "passwordHide": "Skryť heslo",
       "passwordShow": "Ukázať heslo",
       "previous": "Predchádzajúci",
-      "previousPageLabel": "Predchádzajúca strana",
+      "prevPageLabel": "Predchádzajúca strana",
       "removeLabel": "Odstrániť",
       "rotateLeft": "Otočiť doľava",
       "rotateRight": "Otočiť doprava",

--- a/sl.json
+++ b/sl.json
@@ -164,7 +164,7 @@
       "passwordHide": "Skrij geslo",
       "passwordShow": "Pokaži geslo",
       "previous": "Prejšnji",
-      "previousPageLabel": "Prejšnja stran",
+      "prevPageLabel": "Prejšnja stran",
       "removeLabel": "Odstrani",
       "rotateLeft": "Zavrti levo",
       "rotateRight": "Zavrti desno",

--- a/sr-rs.json
+++ b/sr-rs.json
@@ -164,7 +164,7 @@
       "passwordHide": "Сакри лозинку",
       "passwordShow": "Прикажи лозинку",
       "previous": "Претходно",
-      "previousPageLabel": "Претходна страна",
+      "prevPageLabel": "Претходна страна",
       "removeLabel": "Уклони",
       "rotateLeft": "Ротирај лево",
       "rotateRight": "Ротирај десно",

--- a/sv.json
+++ b/sv.json
@@ -165,7 +165,7 @@
       "passwordHide": "Dölj lösenord",
       "passwordShow": "Visa lösenord",
       "previous": "Tidigare",
-      "previousPageLabel": "Föregående sida",
+      "prevPageLabel": "Föregående sida",
       "removeLabel": "Avlägsna",
       "rotateLeft": "Rotera vänster",
       "rotateRight": "Vrid höger",

--- a/th.json
+++ b/th.json
@@ -164,7 +164,7 @@
       "passwordHide": "ซ่อนรหัสผ่าน",
       "passwordShow": "แสดงรหัสผ่าน",
       "previous": "ก่อนหน้า",
-      "previousPageLabel": "หน้าก่อนหน้า",
+      "prevPageLabel": "หน้าก่อนหน้า",
       "removeLabel": "ลบ",
       "rotateLeft": "หมุนไปทางซ้าย",
       "rotateRight": "หมุนไปทางขวา",

--- a/tr.json
+++ b/tr.json
@@ -164,7 +164,7 @@
       "passwordHide": "Şifreyi gizle",
       "passwordShow": "Şifreyi göster",
       "previous": "Önceki",
-      "previousPageLabel": "Önceki Sayfa",
+      "prevPageLabel": "Önceki Sayfa",
       "removeLabel": "Sil",
       "rotateLeft": "Sola Döndür",
       "rotateRight": "Sağa Döndür",

--- a/uk.json
+++ b/uk.json
@@ -164,7 +164,7 @@
       "passwordHide": "Приховати пароль",
       "passwordShow": "Показати пароль",
       "previous": "Попередній",
-      "previousPageLabel": "Попередня сторінка",
+      "prevPageLabel": "Попередня сторінка",
       "removeLabel": "видалити",
       "rotateLeft": "Повернути вліво",
       "rotateRight": "Повернути праворуч",

--- a/uz.json
+++ b/uz.json
@@ -164,7 +164,7 @@
       "passwordHide": "Parolni yashirish",
       "passwordShow": "Parolni ko'rsatish",
       "previous": "Oldingi",
-      "previousPageLabel": "Oldingi sahifa",
+      "prevPageLabel": "Oldingi sahifa",
       "removeLabel": "O'chirish",
       "rotateLeft": "Chapga aylantirish",
       "rotateRight": "O'ngga aylantirish",

--- a/vi.json
+++ b/vi.json
@@ -164,7 +164,7 @@
       "passwordHide": "Ẩn mật khẩu",
       "passwordShow": "Hiển thị mật khẩu",
       "previous": "Trước",
-      "previousPageLabel": "Trang trước",
+      "prevPageLabel": "Trang trước",
       "removeLabel": "Di dời",
       "rotateLeft": "Xoay trái",
       "rotateRight": "Xoay phải",

--- a/zh-CN.json
+++ b/zh-CN.json
@@ -164,7 +164,7 @@
       "passwordHide": "隐藏密码",
       "passwordShow": "显示密码",
       "previous": "上一个",
-      "previousPageLabel": "上一页",
+      "prevPageLabel": "上一页",
       "removeLabel": "消除",
       "rotateLeft": "向左旋转",
       "rotateRight": "向右旋转",

--- a/zh-TW.json
+++ b/zh-TW.json
@@ -164,7 +164,7 @@
       "passwordHide": "隱藏密碼",
       "passwordShow": "顯示密碼",
       "previous": "上一個",
-      "previousPageLabel": "上一頁",
+      "prevPageLabel": "上一頁",
       "removeLabel": "移除",
       "rotateLeft": "向左旋轉",
       "rotateRight": "向右旋轉",


### PR DESCRIPTION
Renames 'previousPageLabel' translation key to 'prevPageLabel' actually used by primeng