### PR TITLE
Fix dateFormat ko.json

### DIFF
--- a/ko.json
+++ b/ko.json
@@ -15,7 +15,7 @@
     "custom": "커스텀",
     "dateAfter": "날짜 후",
     "dateBefore": "날짜 전",
-    "dateFormat": "mm/dd/yy",
+    "dateFormat": "yy-mm-dd",
     "dateIs": "날짜가 같은",
     "dateIsNot": "날짜가 같지 않은",
     "dayNames": [


### PR DESCRIPTION
In the Korea translation (ko.json) the date format is currently: "dateFormat": "dd/mm/yyyy"
It should be
"dateFormat": "yy-mm-dd",

Source:
https://en.wikipedia.org/wiki/Date_and_time_notation_in_South_Korea