### PR TITLE
Add translation for noFileChosenMessage

### DIFF
--- a/pt-br.json
+++ b/pt-br.json
@@ -129,6 +129,7 @@
     "upload": "Enviar",
     "weak": "Fraco",
     "weekHeader": "Sem",
+    "noFileChosenMessage": "Nenhum arquivo escolhido",
     "aria": {
       "cancelEdit": "Cancelar Edição",
       "close": "Fechar",


### PR DESCRIPTION
This merge request includes the updated locale that provides a Portuguese (PT-BR) translation for the "noFileChosenMessage". It ensures a localized experience when no file is selected in the upload component.