### PR TITLE
Fix date formating for hu.json, lt.json and ms.json

### DIFF
--- a/hu.json
+++ b/hu.json
@@ -15,7 +15,7 @@
     "custom": "Egyedi",
     "dateAfter": "Dátum későbbi",
     "dateBefore": "Dátum korábbi",
-    "dateFormat": "yy.mm.dd",
+    "dateFormat": "yy. mm. dd.",
     "dateIs": "Dátum egyenlő",
     "dateIsNot": "Dátum nem egyenlő",
     "dayNames": [

--- a/lt.json
+++ b/lt.json
@@ -15,7 +15,7 @@
     "custom": "Tinkintas",
     "dateAfter": "Data vėlesnė nei",
     "dateBefore": "Data ankstesnė nei",
-    "dateFormat": "yyyy/mm/dd",
+    "dateFormat": "yy-mm-dd",
     "dateIs": "Data yra",
     "dateIsNot": "Data nėra",
     "dayNames": [

--- a/ms.json
+++ b/ms.json
@@ -15,7 +15,7 @@
     "custom": "Khas",
     "dateAfter": "Tarikh selepas",
     "dateBefore": "Tarikh sebelum",
-    "dateFormat": "dd/mm/yyyy",
+    "dateFormat": "dd/mm/yy",
     "dateIs": "Tarikh adalah",
     "dateIsNot": "Tarikh bukan",
     "dayNames": [


### PR DESCRIPTION
This updates `hu.json` and `lt.json` represent the correct date formatting - https://en.wikipedia.org/wiki/List_of_date_formats_by_country

And update `lt.json` and `ms.json` to use `yy` instead of `yyyy` since `yyyy` is intepreted as 2 full years after each other

<img width="427" height="85" alt="grafik" src="https://github.com/user-attachments/assets/81110a19-3d6b-40c0-b8fb-174c98fa4853" />
