### PR TITLE
Fix #238 Remove duplicate 'prevPageLabel' entry

### DIFF
--- a/fi.json
+++ b/fi.json
@@ -168,7 +168,6 @@
       "passwordShow": "Näytä salasana",
       "previous": "Edellinen",
       "prevPageLabel": "Edellinen sivu",
-      "prevPageLabel": "Edellinen sivu",
       "removeLabel": "Poista",
       "rotateLeft": "Pyöritä vasemmalle",
       "rotateRight": "Pyöritä oikealle",


### PR DESCRIPTION
Issue: https://github.com/primefaces/primelocale/issues/238
This PR removes duplicate object key 'prevPageLabel' from file 'fi.json'