### PR TITLE
Update matchAll and matchAny translation for german languages

### DIFF
--- a/de-AT.json
+++ b/de-AT.json
@@ -69,8 +69,8 @@
     "gte": "Größer oder gleich",
     "lt": "Kleiner als",
     "lte": "Kleiner oder gleich",
-    "matchAll": "Passt auf alle",
-    "matchAny": "Passt auf einige",
+    "matchAll": "Trifft auf alle zu",
+    "matchAny": "Trifft auf einige zu",
     "medium": "Mittel",
     "monthNames": [
       "Jänner",

--- a/de-CH.json
+++ b/de-CH.json
@@ -69,8 +69,8 @@
     "gte": "Grösser oder gleich",
     "lt": "Kleiner als",
     "lte": "Kleiner oder gleich",
-    "matchAll": "Passt auf alle",
-    "matchAny": "Passt auf einige",
+    "matchAll": "Trifft auf alle zu",
+    "matchAny": "Trifft auf einige zu",
     "medium": "Mittel",
     "monthNames": [
       "Januar",

--- a/de.json
+++ b/de.json
@@ -69,8 +69,8 @@
     "gte": "Größer oder gleich",
     "lt": "Kleiner als",
     "lte": "Kleiner oder gleich",
-    "matchAll": "Passt auf alle",
-    "matchAny": "Passt auf einige",
+    "matchAll": "Trifft auf alle zu",
+    "matchAny": "Trifft auf einige zu",
     "medium": "Mittel",
     "monthNames": [
       "Januar",


### PR DESCRIPTION
The current translation "Passt auf alle" means something like "A lid can be put on every bottle" rather than "A filter must apply to all statements".
The same applies to "Passt auf einige".