### PR TITLE
Change nl translation for matchingAny

### DIFF
--- a/nl.json
+++ b/nl.json
@@ -70,7 +70,7 @@
     "lt": "Kleiner dan",
     "lte": "Kleiner dan of gelijk aan",
     "matchAll": "Overeenkomen met alle",
-    "matchAny": "Overeenkomen met elke",
+    "matchAny": "Overeenkomen met een",
     "medium": "Gemiddeld",
     "monthNames": [
       "januari",


### PR DESCRIPTION
Google translates the word 'any' to 'elke'.  In some sentences it works, but the words do not carry the same technical denotation.

The wording of 'Overeenkomen met een' is a bit awkward too, but technically correct at least. I'm open to other suggestions, but would like to see the current option changed, as the current translation technically means 'Matching all'.