### PR TITLE
Fix ja aria expand/collapse translations

### DIFF
--- a/ja.json
+++ b/ja.json
@@ -134,10 +134,10 @@
     "aria": {
       "cancelEdit": "キャンセル",
       "close": "閉じる",
-      "collapseLabel": "崩壊",
+      "collapseLabel": "折りたたむ",
       "collapseRow": "折りたたみ行",
       "editRow": "行編集",
-      "expandLabel": "拡大する",
+      "expandLabel": "展開する",
       "expandRow": "展開済行",
       "falseLabel": "False",
       "filterConstraint": "フィルター成約",


### PR DESCRIPTION
Fixes unnatural Japanese aria translations for expand/collapse UI labels.

- expandLabel: "拡大する" -> "展開する"
- collapseLabel: "崩壊" -> "折りたたむ"

These terms are more natural as Japanese UI labels.