### PR TITLE
German: Only use two-letter weekday abbreviations

### DIFF
--- a/de-AT.json
+++ b/de-AT.json
@@ -37,13 +37,13 @@
       "Sa"
     ],
     "dayNamesShort": [
-      "Son",
-      "Mon",
-      "Die",
-      "Mit",
-      "Don",
-      "Fre",
-      "Sam"
+      "So",
+      "Mo",
+      "Di",
+      "Mi",
+      "Do",
+      "Fr",
+      "Sa"
     ],
     "emptyFilterMessage": "Keine Ergebnisse gefunden",
     "emptyMessage": "Keine Einträge gefunden",

--- a/de-CH.json
+++ b/de-CH.json
@@ -37,13 +37,13 @@
       "Sa"
     ],
     "dayNamesShort": [
-      "Son",
-      "Mon",
-      "Die",
-      "Mit",
-      "Don",
-      "Fre",
-      "Sam"
+      "So",
+      "Mo",
+      "Di",
+      "Mi",
+      "Do",
+      "Fr",
+      "Sa"
     ],
     "emptyFilterMessage": "Keine Ergebnisse gefunden",
     "emptyMessage": "Keine Einträge gefunden",

--- a/de.json
+++ b/de.json
@@ -37,13 +37,13 @@
       "Sa"
     ],
     "dayNamesShort": [
-      "Son",
-      "Mon",
-      "Die",
-      "Mit",
-      "Don",
-      "Fre",
-      "Sam"
+      "So",
+      "Mo",
+      "Di",
+      "Mi",
+      "Do",
+      "Fr",
+      "Sa"
     ],
     "emptyFilterMessage": "Keine Ergebnisse gefunden",
     "emptyMessage": "Keine Einträge gefunden",


### PR DESCRIPTION
In German-speaking countries, only the two-letter abbreviations are used for the days of the week (like Catalan). The use of three-letter abbreviations is very uncommon.