### PR TITLE
Fix ja aria filterConstraint translation (成約 → 制約)

### DIFF
--- a/ja.json
+++ b/ja.json
@@ -140,7 +140,7 @@
       "expandLabel": "展開する",
       "expandRow": "展開済行",
       "falseLabel": "False",
-      "filterConstraint": "フィルター成約",
+      "filterConstraint": "フィルター制約",
       "filterOperator": "フィルター操作",
       "firstPageLabel": "最初のページ",
       "gridView": "グリッドビュー",


### PR DESCRIPTION
ja `aria.filterConstraint` is currently "フィルター成約". 成約 (せいやく) means "closing a sales deal" and only happens to share its reading with the word that was meant. The English source is "Filter Constraint", and the right kanji for that "constraint" sense is 制約, so this should be "フィルター制約".

For reference, zh-CN uses 筛选条件 and ko keeps "Constraint", so ja was the only locale carrying the wrong word here.

This is the same kind of slip #261 fixed for collapseLabel and expandLabel in this aria block.
